### PR TITLE
Change return type to dict for 'all()' with a filter

### DIFF
--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -21,9 +21,10 @@ class FileStorage:
         """Returns a dictionary of models currently in the file storage,
         filtered by the type of class, if provided."""
         if cls:
-            return [
-                obj for obj in self.__objects.values() if isinstance(obj, cls)
-            ]
+            return {
+                k: v for k, v in self.__objects.items() if isinstance(v, cls)
+            }
+
         return self.__objects
 
     def new(self, obj):


### PR DESCRIPTION
I have reviewed the attached image and found that the initial implementation returned a list of objects, which was correct according to the task's requirements. However, I later discovered that this was causing a bug, and the output needed to be a dictionary instead. I realized this after testing the driver code provided, which required a dictionary output. Therefore, I have made the necessary updates to fix the bug and ensure the output is a dictionary as needed.

![image](https://github.com/nanafox/AirBnB_clone_v2/assets/48143641/0999d8c8-6969-4f27-b936-5c72687bd5b5)
