### PR TITLE
Add close method to file storage and refactor state.py

### DIFF
--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -21,9 +21,7 @@ class FileStorage:
         """Returns a dictionary of models currently in the file storage,
         filtered by the type of class, if provided."""
         if cls:
-            return {
-                k: v for k, v in self.__objects.items() if isinstance(v, cls)
-            }
+            return {k: v for k, v in self.__objects.items() if isinstance(v, cls)}
 
         return self.__objects
 
@@ -65,3 +63,7 @@ class FileStorage:
         if obj is not None:
             obj_key = f"{obj.__class__.__name__}.{obj.id}"
             del self.__objects[obj_key]
+
+    def close(self):
+        """Closes the session and reloads the contents in the storage."""
+        self.reload()

--- a/models/state.py
+++ b/models/state.py
@@ -20,7 +20,7 @@ class State(BaseModel, Base):
             "City", backref="state", cascade="all, delete, delete-orphan"
         )
 
-    elif getenv("HBNB_TYPE_STORAGE") == "file":
+    else:  # assume file storage if DB storage is not explicitly set
 
         @property
         def cities(self):


### PR DESCRIPTION
This pull request adds a new `close` method to the file storage class and refactors the `state.py` file to handle file storage if DB storage is not explicitly set. The `close` method closes the session and reloads the contents in the storage.